### PR TITLE
fix: add missing await for async artifact link parser calls

### DIFF
--- a/src/ArtifactLinkToURL.js
+++ b/src/ArtifactLinkToURL.js
@@ -148,7 +148,7 @@ export async function TryGetHTMLLinkNameAndUrlForArtifactLink(currentProjectName
             }
         };
 
-        return parsers[artifactTool]?.[artifactType]?.(artifactLink, artifactId, currentProjectName);
+        return await parsers[artifactTool]?.[artifactType]?.(artifactLink, artifactId, currentProjectName);
     }
     catch (ex) {
         console.log(`HistoryDiff: Exception while parsing artifact link '${artifactLink}': ${ex}`);


### PR DESCRIPTION
Without await, the Promise returned by the async parser functions (e.g. ParseArtifactLinkVersionControlChangeset) escapes the surrounding try/catch block. When routeUrl() rejects (e.g. for TFVC changeset routes on certain TFS configurations), the unhandled rejection propagates all the way up to LoadAndSetDiffInHTMLDocument and crashes the entire history diff rendering.

Adding await ensures the exception is caught locally and the extension gracefully falls back to showing the raw link text instead.